### PR TITLE
feat: add timeout and cache headers to health endpoint

### DIFF
--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -13,6 +13,8 @@ interface HealthCheck {
   };
 }
 
+const DB_TIMEOUT_MS = 5000;
+
 export async function GET() {
   const memoryUsage = process.memoryUsage();
 
@@ -22,7 +24,12 @@ export async function GET() {
 
   try {
     const start = Date.now();
-    await db.execute(sql`SELECT 1`);
+    await Promise.race([
+      db.execute(sql`SELECT 1`),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("Database timeout")), DB_TIMEOUT_MS)
+      ),
+    ]);
     dbLatency = Date.now() - start;
   } catch (error) {
     dbStatus = "unhealthy";
@@ -52,5 +59,8 @@ export async function GET() {
 
   return NextResponse.json(health, {
     status: overallStatus === "healthy" ? 200 : 503,
+    headers: {
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+    },
   });
 }


### PR DESCRIPTION
## Resumo

- Adiciona timeout de 5s no health check do banco para evitar hang em caso de DB lento
- Adiciona headers `Cache-Control: no-cache` para garantir status atualizado

## Motivacao

O endpoint `/api/health` e usado para monitoramento externo. Sem timeout, uma conexao lenta ao banco pode travar a resposta indefinidamente. Sem cache headers, proxies podem cachear um status "healthy" desatualizado.

## Teste

- Verificar que `/api/health` retorna em menos de 5s mesmo com DB lento
- Verificar header `Cache-Control: no-cache, no-store, must-revalidate` na resposta