### PR TITLE
fix(security): rate limiting distribuido (Upstash, fail-closed) + hardening de tenant/CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,12 @@ DATABASE_URL=postgresql://user:password@host/database?sslmode=require
 AUTH_SECRET=your-auth-secret
 NEXTAUTH_URL=http://localhost:3000
 NEXT_PUBLIC_SENTRY_DSN=
+
+# Rate limiting distribuido (Upstash Redis) — OBRIGATORIO em producao.
+# Sem estas vars em producao, rotas rate-limitadas respondem 503 (fail-closed).
+# Em dev, ausencia ativa fallback in-memory.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# CORS — origem do app. OBRIGATORIO em producao (sem fallback localhost em prod).
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "@neondatabase/serverless": "^1.0.2",
     "@sentry/nextjs": "^10.43.0",
     "@t3-oss/env-nextjs": "^0.13.11",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0",
     "@vercel/analytics": "^1.0.0",
     "@vercel/speed-insights": "^1.0.0",
     "ai": "^6.0.141",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: ^0.13.11
         version: 0.13.11(typescript@5.9.3)(zod@4.3.6)
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
       '@vercel/analytics':
         specifier: ^1.0.0
         version: 1.6.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -52,7 +58,7 @@ importers:
         version: 4.1.0
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)
+        version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0)
       lucide-react:
         specifier: ^0.577.0
         version: 0.577.0(react@19.2.5)
@@ -1059,89 +1065,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1270,24 +1292,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.2':
     resolution: {integrity: sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.2':
     resolution: {integrity: sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.2':
     resolution: {integrity: sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.2':
     resolution: {integrity: sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==}
@@ -1614,36 +1640,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -1726,66 +1758,79 @@ packages:
     resolution: {integrity: sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.0':
     resolution: {integrity: sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.0':
     resolution: {integrity: sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.0':
     resolution: {integrity: sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.0':
     resolution: {integrity: sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.0':
     resolution: {integrity: sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.0':
     resolution: {integrity: sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.0':
     resolution: {integrity: sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.0':
     resolution: {integrity: sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.0':
     resolution: {integrity: sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.0':
     resolution: {integrity: sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.0':
     resolution: {integrity: sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.0':
     resolution: {integrity: sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.0':
     resolution: {integrity: sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==}
@@ -2062,24 +2107,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2364,41 +2413,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2419,6 +2476,18 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -4199,24 +4268,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5377,6 +5450,9 @@ packages:
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -7711,6 +7787,19 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
+
   '@vercel/analytics@1.6.1(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
       next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.5))(react@19.2.5)
@@ -8398,11 +8487,12 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0):
+  drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@upstash/redis@1.38.0):
     optionalDependencies:
       '@neondatabase/serverless': 1.0.2
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
+      '@upstash/redis': 1.38.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -10873,6 +10963,8 @@ snapshots:
       has-bigints: 1.1.0
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 

--- a/src/__tests__/lib/cors.test.ts
+++ b/src/__tests__/lib/cors.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { buildAllowedOrigins } from "@/lib/cors";
+
+describe("buildAllowedOrigins", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("inclui NEXT_PUBLIC_APP_URL quando configurada", () => {
+    const origins = buildAllowedOrigins({
+      NEXT_PUBLIC_APP_URL: "https://app.example.com",
+      NODE_ENV: "production",
+    });
+    expect(origins).toContain("https://app.example.com");
+    expect(origins).not.toContain("http://localhost:3000");
+  });
+
+  it("fallback localhost APENAS fora de producao", () => {
+    const origins = buildAllowedOrigins({ NODE_ENV: "development" });
+    expect(origins).toContain("http://localhost:3000");
+  });
+
+  it("em producao sem NEXT_PUBLIC_APP_URL, NAO adiciona localhost e loga erro", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const origins = buildAllowedOrigins({ NODE_ENV: "production" });
+
+    expect(origins).not.toContain("http://localhost:3000");
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain("NEXT_PUBLIC_APP_URL ausente em produção");
+  });
+
+  it("mantem os dominios fixos em qualquer ambiente", () => {
+    for (const NODE_ENV of ["development", "production", "test"]) {
+      const origins = buildAllowedOrigins({ NODE_ENV });
+      expect(origins).toContain("https://redenexial.com");
+      expect(origins).toContain("https://restaurant-crm-iota.vercel.app");
+    }
+  });
+});

--- a/src/__tests__/security/rate-limit-fail-closed.test.ts
+++ b/src/__tests__/security/rate-limit-fail-closed.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Semantica do rate limiter distribuido (createRateLimiter):
+ *
+ * 1. Producao SEM Upstash configurado → fail-closed (RateLimitUnavailableError / 503).
+ * 2. Dev/test SEM Upstash → fallback in-memory (429 ao exceder limite).
+ * 3. Upstash configurado → usa @upstash/ratelimit (429 quando success=false).
+ * 4. Upstash configurado mas inacessivel (erro de rede) → fail-open com log.
+ */
+
+const { limitMock } = vi.hoisted(() => ({
+  limitMock: vi.fn(),
+}));
+
+vi.mock("@upstash/redis", () => ({
+  Redis: vi.fn(),
+}));
+
+vi.mock("@upstash/ratelimit", () => {
+  class Ratelimit {
+    static slidingWindow = vi.fn(() => "sliding-window");
+    limit = limitMock;
+  }
+  return { Ratelimit };
+});
+
+import {
+  createRateLimiter,
+  RateLimitError,
+  RateLimitUnavailableError,
+} from "@/lib/rate-limit";
+import { logger } from "@/lib/logger";
+
+function freshLimiter(overrides?: Partial<Parameters<typeof createRateLimiter>[0]>) {
+  return createRateLimiter({
+    limit: 2,
+    interval: 60_000,
+    prefix: "test",
+    uniqueTokenPerInterval: 10,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  limitMock.mockReset();
+  vi.stubEnv("UPSTASH_REDIS_REST_URL", "");
+  vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("createRateLimiter — fail-closed em producao", () => {
+  it("lanca RateLimitUnavailableError (503) em producao sem envs Upstash", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+    const limiter = freshLimiter();
+
+    await expect(limiter.check("ip-1")).rejects.toThrow(RateLimitUnavailableError);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain("fail-closed");
+  });
+
+  it("RateLimitUnavailableError tem status 503", () => {
+    const error = new RateLimitUnavailableError();
+    expect(error.status).toBe(503);
+    expect(error.name).toBe("RateLimitUnavailableError");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("nunca e no-op silencioso: em producao sem Upstash, TODA chamada falha", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.spyOn(logger, "error").mockImplementation(() => {});
+
+    const limiter = freshLimiter();
+
+    for (let i = 0; i < 3; i++) {
+      await expect(limiter.check(`ip-${i}`)).rejects.toThrow(RateLimitUnavailableError);
+    }
+  });
+});
+
+describe("createRateLimiter — fallback in-memory em dev", () => {
+  it("fora de producao sem Upstash, aplica limite in-memory (429)", async () => {
+    // NODE_ENV=test no vitest — cai no fallback dev
+    const limiter = freshLimiter({ limit: 2 });
+
+    await expect(limiter.check("dev-ip")).resolves.toBeUndefined();
+    await expect(limiter.check("dev-ip")).resolves.toBeUndefined();
+    await expect(limiter.check("dev-ip")).rejects.toThrow(RateLimitError);
+  });
+
+  it("tokens diferentes nao interferem no fallback dev", async () => {
+    const limiter = freshLimiter({ limit: 1 });
+
+    await expect(limiter.check("dev-a")).resolves.toBeUndefined();
+    await expect(limiter.check("dev-a")).rejects.toThrow(RateLimitError);
+    await expect(limiter.check("dev-b")).resolves.toBeUndefined();
+  });
+});
+
+describe("createRateLimiter — Upstash configurado", () => {
+  beforeEach(() => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://fake.upstash.io");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "fake-token");
+  });
+
+  it("permite request quando Upstash retorna success=true", async () => {
+    limitMock.mockResolvedValue({ success: true, remaining: 1 });
+    const limiter = freshLimiter();
+
+    await expect(limiter.check("ip-ok")).resolves.toBeUndefined();
+    expect(limitMock).toHaveBeenCalledWith("ip-ok");
+  });
+
+  it("lanca RateLimitError (429) quando Upstash retorna success=false", async () => {
+    limitMock.mockResolvedValue({ success: false, remaining: 0 });
+    const limiter = freshLimiter();
+
+    await expect(limiter.check("ip-blocked")).rejects.toThrow(RateLimitError);
+  });
+
+  it("usa Upstash mesmo em producao (sem fail-closed) quando envs presentes", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    limitMock.mockResolvedValue({ success: true, remaining: 5 });
+    const limiter = freshLimiter();
+
+    await expect(limiter.check("prod-ip")).resolves.toBeUndefined();
+  });
+
+  it("fail-open com log quando Redis esta inacessivel (erro transiente)", async () => {
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    limitMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    const limiter = freshLimiter();
+
+    await expect(limiter.check("ip-net-fail")).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain("fail-open");
+  });
+});

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,8 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { handlers } from "@/lib/auth";
-import { rateLimit, RateLimitError } from "@/lib/rate-limit";
+import { createRateLimiter, RateLimitError, RateLimitUnavailableError } from "@/lib/rate-limit";
 
-const authLimiter = rateLimit({ interval: 60_000, uniqueTokenPerInterval: 500 });
+const authLimiter = createRateLimiter({
+  limit: 10,
+  interval: 60_000,
+  prefix: "auth-login",
+  uniqueTokenPerInterval: 500,
+});
 
 export const { GET } = handlers;
 
@@ -11,12 +16,18 @@ export async function POST(req: NextRequest) {
   if (req.nextUrl.pathname.includes("callback/credentials")) {
     const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
     try {
-      await authLimiter.check(10, ip);
+      await authLimiter.check(ip);
     } catch (e) {
       if (e instanceof RateLimitError) {
         return NextResponse.json(
           { error: "Demasiadas tentativas de login. Tente novamente em 1 minuto." },
           { status: 429, headers: { "Retry-After": "60" } }
+        );
+      }
+      if (e instanceof RateLimitUnavailableError) {
+        return NextResponse.json(
+          { error: "Serviço temporariamente indisponível. Tente novamente." },
+          { status: 503, headers: { "Retry-After": "30" } }
         );
       }
       throw e;

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -5,18 +5,26 @@ import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { registerSchema } from "@/lib/validations/auth";
 import { successResponse, errorResponse, handleApiError } from "@/lib/api-utils";
-import { rateLimit, RateLimitError } from "@/lib/rate-limit";
+import { createRateLimiter, RateLimitError, RateLimitUnavailableError } from "@/lib/rate-limit";
 
-const registerLimiter = rateLimit({ interval: 60_000, uniqueTokenPerInterval: 100 });
+const registerLimiter = createRateLimiter({
+  limit: 5,
+  interval: 60_000,
+  prefix: "register",
+  uniqueTokenPerInterval: 100,
+});
 
 export async function POST(req: NextRequest) {
   try {
     const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
     try {
-      await registerLimiter.check(5, ip);
+      await registerLimiter.check(ip);
     } catch (e) {
       if (e instanceof RateLimitError) {
         return errorResponse("Demasiadas tentativas. Tente novamente em 1 minuto.", 429);
+      }
+      if (e instanceof RateLimitUnavailableError) {
+        return errorResponse("Serviço temporariamente indisponível. Tente novamente.", 503);
       }
       throw e;
     }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -4,9 +4,14 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { sops } from "@/db/schema";
 import { and, eq } from "drizzle-orm";
-import { rateLimit, RateLimitError } from "@/lib/rate-limit";
+import { createRateLimiter, RateLimitError, RateLimitUnavailableError } from "@/lib/rate-limit";
 
-const chatLimiter = rateLimit({ interval: 60_000, uniqueTokenPerInterval: 500 });
+const chatLimiter = createRateLimiter({
+  limit: 10,
+  interval: 60_000,
+  prefix: "chat",
+  uniqueTokenPerInterval: 500,
+});
 
 export async function POST(req: Request) {
   const session = await auth();
@@ -16,10 +21,15 @@ export async function POST(req: Request) {
 
   // Rate limit: 10 requests/min per user
   try {
-    await chatLimiter.check(10, session.user.id!);
+    await chatLimiter.check(session.user.id!);
   } catch (e) {
     if (e instanceof RateLimitError) {
       return new Response("Limite de requisicoes excedido. Tente em 1 minuto.", { status: 429 });
+    }
+    if (e instanceof RateLimitUnavailableError) {
+      return new Response("Serviço temporariamente indisponível. Tente novamente.", {
+        status: 503,
+      });
     }
     throw e;
   }

--- a/src/lib/api-with-rate-limit.ts
+++ b/src/lib/api-with-rate-limit.ts
@@ -1,11 +1,18 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { defaultRateLimiter, RateLimitError, rateLimit } from "./rate-limit";
+import {
+  createRateLimiter,
+  DistributedRateLimiter,
+  RateLimitError,
+  RateLimitUnavailableError,
+} from "./rate-limit";
 
 interface RateLimitWrapperOptions {
   limit?: number;
   interval?: number;
   uniqueTokenPerInterval?: number;
+  /** Prefixo das chaves no Redis. Default: "api". */
+  prefix?: string;
 }
 
 type ApiHandler = (request: NextRequest, context?: unknown) => Promise<NextResponse> | NextResponse;
@@ -19,7 +26,7 @@ function extractIp(request: NextRequest): string {
 }
 
 /**
- * Wrapper que aplica rate limit antes de chamar o handler.
+ * Wrapper que aplica rate limit (Upstash, fail-closed em prod) antes do handler.
  * Extrai IP do request como token de identificacao.
  *
  * Uso:
@@ -27,22 +34,20 @@ function extractIp(request: NextRequest): string {
  *   export const POST = withRateLimit(handler, { limit: 10 });
  */
 export function withRateLimit(handler: ApiHandler, options?: RateLimitWrapperOptions): ApiHandler {
-  const limit = options?.limit ?? 60;
+  const interval = options?.interval ?? 60_000;
 
-  // Usa limiter customizado se interval ou uniqueTokenPerInterval forem passados
-  const limiter =
-    options?.interval || options?.uniqueTokenPerInterval
-      ? rateLimit({
-          interval: options?.interval ?? 60_000,
-          uniqueTokenPerInterval: options?.uniqueTokenPerInterval ?? 500,
-        })
-      : defaultRateLimiter;
+  const limiter: DistributedRateLimiter = createRateLimiter({
+    limit: options?.limit ?? 60,
+    interval,
+    prefix: options?.prefix ?? "api",
+    uniqueTokenPerInterval: options?.uniqueTokenPerInterval ?? 500,
+  });
 
   return async (request: NextRequest, context?: unknown) => {
     const ip = extractIp(request);
 
     try {
-      await limiter.check(limit, ip);
+      await limiter.check(ip);
     } catch (error) {
       if (error instanceof RateLimitError) {
         return NextResponse.json(
@@ -53,9 +58,18 @@ export function withRateLimit(handler: ApiHandler, options?: RateLimitWrapperOpt
           {
             status: 429,
             headers: {
-              "Retry-After": String(Math.ceil((options?.interval ?? 60_000) / 1000)),
+              "Retry-After": String(Math.ceil(interval / 1000)),
             },
           }
+        );
+      }
+      if (error instanceof RateLimitUnavailableError) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: "Serviço temporariamente indisponível. Tente novamente.",
+          },
+          { status: 503, headers: { "Retry-After": "30" } }
         );
       }
       throw error;

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -1,0 +1,29 @@
+/**
+ * Allowlist de origens CORS.
+ *
+ * - NEXT_PUBLIC_APP_URL configurada: entra na allowlist.
+ * - Sem NEXT_PUBLIC_APP_URL fora de producao: fallback http://localhost:3000.
+ * - Sem NEXT_PUBLIC_APP_URL EM producao: nenhuma origem adicional
+ *   (apenas os dominios fixos) + log de erro. Nunca localhost em prod.
+ */
+
+const STATIC_ORIGINS = ["https://redenexial.com", "https://restaurant-crm-iota.vercel.app"];
+
+export function buildAllowedOrigins(env: {
+  NEXT_PUBLIC_APP_URL?: string;
+  NODE_ENV?: string;
+}): string[] {
+  const origins = [...STATIC_ORIGINS];
+
+  if (env.NEXT_PUBLIC_APP_URL) {
+    origins.unshift(env.NEXT_PUBLIC_APP_URL);
+  } else if (env.NODE_ENV !== "production") {
+    origins.unshift("http://localhost:3000");
+  } else {
+    console.error(
+      "[cors] NEXT_PUBLIC_APP_URL ausente em produção — nenhuma origem de app adicionada à allowlist CORS"
+    );
+  }
+
+  return origins;
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,7 +1,18 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
+
+import { logger } from "./logger";
+
 /**
- * Rate limiter in-memory usando Map.
- * Adequado para dev e single-instance.
- * Para producao multi-instance, substituir por Redis.
+ * Rate limiting distribuido via Upstash Redis (@upstash/ratelimit).
+ *
+ * Semantica por ambiente:
+ * - Upstash configurado (UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN):
+ *   sliding window distribuido — funciona em Vercel serverless multi-instance.
+ * - Producao SEM Upstash: fail-closed — toda rota rate-limitada responde 503
+ *   (RateLimitUnavailableError) com log de erro. Nunca no-op silencioso.
+ * - Dev/test sem Upstash: fallback para o limiter in-memory (Map),
+ *   adequado a single-instance local.
  */
 
 interface RateLimitOptions {
@@ -24,6 +35,21 @@ export class RateLimitError extends Error {
   }
 }
 
+export class RateLimitUnavailableError extends Error {
+  status: number;
+
+  constructor(message = "Rate limiting indisponível. Tente novamente em instantes.") {
+    super(message);
+    this.name = "RateLimitUnavailableError";
+    this.status = 503;
+  }
+}
+
+/**
+ * Limiter in-memory usando Map.
+ * Usado APENAS como fallback de dev/test quando Upstash nao esta configurado.
+ * Em producao serverless e inutil (cada invocacao tem memoria propria).
+ */
 export function rateLimit(options: RateLimitOptions) {
   const { interval, uniqueTokenPerInterval } = options;
   const tokenMap = new Map<string, TokenRecord>();
@@ -74,8 +100,91 @@ export function rateLimit(options: RateLimitOptions) {
   };
 }
 
-// Instancia default: 60 requests por minuto, ate 500 IPs unicos
-export const defaultRateLimiter = rateLimit({
-  interval: 60 * 1000,
-  uniqueTokenPerInterval: 500,
-});
+export interface DistributedRateLimiterOptions {
+  /** Max de requests por janela */
+  limit: number;
+  /** Janela em ms */
+  interval: number;
+  /** Prefixo das chaves no Redis (ex: "register", "auth-login", "chat") */
+  prefix: string;
+  /** Apenas para o fallback in-memory de dev */
+  uniqueTokenPerInterval?: number;
+}
+
+export interface DistributedRateLimiter {
+  /**
+   * Lanca RateLimitError (429) se o token excedeu o limite.
+   * Lanca RateLimitUnavailableError (503) em producao sem Upstash configurado.
+   */
+  check(token: string): Promise<void>;
+}
+
+function resolveUpstash(opts: DistributedRateLimiterOptions): Ratelimit | null {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    return null;
+  }
+  return new Ratelimit({
+    redis: new Redis({ url, token }),
+    limiter: Ratelimit.slidingWindow(opts.limit, `${Math.ceil(opts.interval / 1000)} s`),
+    analytics: true,
+    prefix: `crm:${opts.prefix}`,
+  });
+}
+
+/**
+ * Cria um rate limiter distribuido (Upstash) com fail-closed em producao
+ * e fallback in-memory em dev/test.
+ */
+export function createRateLimiter(opts: DistributedRateLimiterOptions): DistributedRateLimiter {
+  // undefined = ainda nao resolvido; null = Upstash nao configurado
+  let upstash: Ratelimit | null | undefined;
+  let memoryFallback: ReturnType<typeof rateLimit> | null = null;
+
+  return {
+    async check(token: string): Promise<void> {
+      if (upstash === undefined) {
+        upstash = resolveUpstash(opts);
+      }
+
+      if (upstash) {
+        let success: boolean;
+        try {
+          const result = await upstash.limit(token);
+          success = result.success;
+        } catch (error) {
+          // Redis configurado mas inacessivel (erro transiente de rede):
+          // fail-open com log — indisponibilidade de Redis nao derruba login/registro.
+          logger.error("[rate-limit] Upstash inacessível — request liberado (fail-open)", {
+            prefix: opts.prefix,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          return;
+        }
+        if (!success) {
+          throw new RateLimitError();
+        }
+        return;
+      }
+
+      // Upstash NAO configurado
+      if (process.env.NODE_ENV === "production") {
+        logger.error(
+          "[rate-limit] UPSTASH_REDIS_REST_URL/TOKEN ausentes em produção — fail-closed (503)",
+          { prefix: opts.prefix }
+        );
+        throw new RateLimitUnavailableError();
+      }
+
+      // Dev/test: fallback in-memory
+      if (!memoryFallback) {
+        memoryFallback = rateLimit({
+          interval: opts.interval,
+          uniqueTokenPerInterval: opts.uniqueTokenPerInterval ?? 500,
+        });
+      }
+      return memoryFallback.check(opts.limit, token);
+    },
+  };
+}

--- a/src/lib/tenant.ts
+++ b/src/lib/tenant.ts
@@ -80,10 +80,3 @@ export async function getChildTenants(parentId: string) {
     .from(tenants)
     .where(and(eq(tenants.parentId, parentId), eq(tenants.active, true)));
 }
-
-/**
- * Resolve tenant from request headers (for API routes)
- */
-export function getTenantIdFromHeaders(headers: Headers): string | null {
-  return headers.get("x-tenant-id");
-}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,11 @@
 import { auth } from "@/lib/auth";
 import { NextResponse } from "next/server";
+import { buildAllowedOrigins } from "@/lib/cors";
 
-const ALLOWED_ORIGINS = [
-  process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
-  "https://redenexial.com",
-  "https://restaurant-crm-iota.vercel.app",
-];
+const ALLOWED_ORIGINS = buildAllowedOrigins({
+  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+  NODE_ENV: process.env.NODE_ENV,
+});
 
 export default auth((req) => {
   const response = NextResponse.next();
@@ -15,10 +15,7 @@ export default auth((req) => {
   if (isApiRoute && ALLOWED_ORIGINS.includes(origin)) {
     response.headers.set("Access-Control-Allow-Origin", origin);
     response.headers.set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS");
-    response.headers.set(
-      "Access-Control-Allow-Headers",
-      "Content-Type, Authorization, X-Tenant-Id"
-    );
+    response.headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
     response.headers.set("Access-Control-Max-Age", "86400");
   }
 


### PR DESCRIPTION
## Contexto

Hardening aprovado em auditoria. App Next.js + Drizzle em producao na Vercel (serverless).

## Findings corrigidos (com evidencia)

### 1. ALTO — Rate limiter in-memory inutil em serverless
- `src/lib/rate-limit.ts:1-5` (antes): Map in-memory — cada invocacao serverless tem memoria propria, entao o limite nunca acumulava em producao.
- Rotas afetadas: `src/app/api/auth/register/route.ts` (5 req/min por IP), `src/app/api/auth/[...nextauth]/route.ts` (10 req/min por IP em callback/credentials), `src/app/api/chat/route.ts` (10 req/min por usuario, chama LLM).

**Fix:** porta para `@upstash/ratelimit` + `@upstash/redis` (mesmo padrao do cortex-fc), com semantica:
- **Producao sem `UPSTASH_REDIS_REST_URL`/`UPSTASH_REDIS_REST_TOKEN`: fail-closed** — rotas rate-limitadas respondem **503** com log de erro. Nunca no-op silencioso.
- Dev/test sem Upstash: fallback para o limiter in-memory original (mantido e testado).
- Upstash configurado mas inacessivel (erro transiente de rede): fail-open com log de erro — indisponibilidade momentanea de Redis nao derruba login/registro (mesma decisao do cortex-fc).
- `src/lib/api-with-rate-limit.ts` (wrapper `withRateLimit`) portado para o mesmo mecanismo.

### 3. BAIXO — Dead code perigoso: tenant via header do cliente
- `src/lib/tenant.ts:87-88` (antes): `getTenantIdFromHeaders` lia `x-tenant-id` controlado pelo cliente — bypass latente de tenant isolation.
- Verificado por grep: **zero usos em `src/`** (nem em testes). Funcao apagada.
- `src/middleware.ts:19-21` (antes): `X-Tenant-Id` removido dos `Access-Control-Allow-Headers`.

### 4. BAIXO — CORS com fallback localhost em producao
- `src/middleware.ts:5` (antes): `process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"` entrava na allowlist mesmo em producao.
- **Fix:** logica extraida para `src/lib/cors.ts` — fallback localhost APENAS quando `NODE_ENV !== "production"`; em producao sem `NEXT_PUBLIC_APP_URL`, nenhuma origem de app e adicionada e um erro e logado.

## Testes

- Novos: `src/__tests__/security/rate-limit-fail-closed.test.ts` (9 testes — fail-closed em prod, fallback dev, 429 via Upstash, fail-open em erro transiente) e `src/__tests__/lib/cors.test.ts` (4 testes).
- `pnpm typecheck`: verde. `pnpm lint`: 0 erros (37 warnings pre-existentes).
- `pnpm test`: **605 passed | 5 failed** — os mesmos 5 falham na `main` limpa (592 passed | 5 failed): `src/__tests__/components/*` (4 arquivos) e `src/__tests__/security/auth-middleware.test.ts` (matcher desatualizado vs `src/middleware.ts:33`). Pre-existentes, fora do escopo deste PR.

## Acao necessaria antes do merge/deploy

- **Setar `UPSTASH_REDIS_REST_URL` e `UPSTASH_REDIS_REST_TOKEN` na Vercel (Production e Preview)** — sem elas, register/login/chat respondem 503 em producao (comportamento fail-closed intencional).
- Confirmar `NEXT_PUBLIC_APP_URL` setada em Production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)