### PR TITLE
feat(api): paginacao opt-in (page/limit) nos endpoints de listagem de maior volume

### DIFF
--- a/src/__tests__/services/pagination.test.ts
+++ b/src/__tests__/services/pagination.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { vi } from "vitest";
+
+/**
+ * Services de listagem paginados.
+ *
+ * Mock chainable do Drizzle: registra os metodos chamados na query builder
+ * e resolve com linhas fake. Verifica:
+ * - sem pagination: NAO aplica limit/offset (compat — lista completa)
+ * - com pagination: aplica limit(n) e offset(n)
+ * - count*: retorna numero a partir de count(*)
+ */
+
+interface RecordedCall {
+  method: string;
+  args: unknown[];
+}
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    calls: [] as { method: string; args: unknown[] }[],
+    rows: [] as unknown[],
+  },
+}));
+
+vi.mock("@/db", () => {
+  const handler: ProxyHandler<object> = {
+    get(_target, prop) {
+      if (prop === "then") {
+        return (resolve: (v: unknown) => void) => resolve(state.rows);
+      }
+      return (...args: unknown[]) => {
+        state.calls.push({ method: String(prop), args });
+        return proxy;
+      };
+    },
+  };
+  const proxy: object = new Proxy({}, handler);
+  return { db: proxy };
+});
+
+import { getAllCustomers, countCustomers } from "@/services/customers";
+import { getAllOrders, countOrders } from "@/services/orders";
+import { getAllReservations, countReservations } from "@/services/reservations";
+import { getAllBalances, countBalances } from "@/services/loyalty";
+import { getNotifications, countNotifications } from "@/services/notifications";
+
+function methodsCalled(): string[] {
+  return state.calls.map((c: RecordedCall) => c.method);
+}
+
+function callArgs(method: string): unknown[] | undefined {
+  return state.calls.find((c: RecordedCall) => c.method === method)?.args;
+}
+
+beforeEach(() => {
+  state.calls = [];
+  state.rows = [];
+});
+
+const PAGINATION = { limit: 25, offset: 50 };
+
+describe.each([
+  ["getAllCustomers", (p?: { limit: number; offset: number }) => getAllCustomers("t1", p)],
+  ["getAllOrders", (p?: { limit: number; offset: number }) => getAllOrders("t1", p)],
+  ["getAllReservations", (p?: { limit: number; offset: number }) => getAllReservations("t1", p)],
+  ["getAllBalances", (p?: { limit: number; offset: number }) => getAllBalances("t1", p)],
+  ["getNotifications", (p?: { limit: number; offset: number }) => getNotifications("t1", "u1", p)],
+])("%s", (_name, invoke) => {
+  it("sem pagination NAO aplica limit/offset (compat)", async () => {
+    state.rows = [{ id: 1 }, { id: 2 }];
+    const result = await invoke(undefined);
+
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(methodsCalled()).not.toContain("limit");
+    expect(methodsCalled()).not.toContain("offset");
+  });
+
+  it("com pagination aplica limit e offset no Drizzle", async () => {
+    state.rows = [{ id: 51 }];
+    const result = await invoke(PAGINATION);
+
+    expect(result).toEqual([{ id: 51 }]);
+    expect(callArgs("limit")).toEqual([25]);
+    expect(callArgs("offset")).toEqual([50]);
+  });
+});
+
+describe.each([
+  ["countCustomers", () => countCustomers("t1")],
+  ["countOrders", () => countOrders("t1")],
+  ["countReservations", () => countReservations("t1")],
+  ["countBalances", () => countBalances("t1")],
+  ["countNotifications", () => countNotifications("t1", "u1")],
+])("%s", (_name, invoke) => {
+  it("retorna total numerico a partir de count(*)", async () => {
+    state.rows = [{ count: "137" }];
+    await expect(invoke()).resolves.toBe(137);
+  });
+
+  it("retorna 0 quando nao ha linhas", async () => {
+    state.rows = [];
+    await expect(invoke()).resolves.toBe(0);
+  });
+});

--- a/src/__tests__/validations/pagination.test.ts
+++ b/src/__tests__/validations/pagination.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { ZodError } from "zod";
+import { paginationQuerySchema, parsePaginationParams } from "@/lib/validations/pagination";
+
+describe("paginationQuerySchema", () => {
+  it("aplica defaults page=1 limit=50", () => {
+    const parsed = paginationQuerySchema.parse({});
+    expect(parsed).toEqual({ page: 1, limit: 50 });
+  });
+
+  it("coage strings numericas da query string", () => {
+    const parsed = paginationQuerySchema.parse({ page: "3", limit: "25" });
+    expect(parsed).toEqual({ page: 3, limit: 25 });
+  });
+
+  it("rejeita limit acima de 100", () => {
+    expect(() => paginationQuerySchema.parse({ limit: "101" })).toThrow(ZodError);
+  });
+
+  it("rejeita page < 1, zero e negativos", () => {
+    expect(() => paginationQuerySchema.parse({ page: "0" })).toThrow(ZodError);
+    expect(() => paginationQuerySchema.parse({ page: "-2" })).toThrow(ZodError);
+    expect(() => paginationQuerySchema.parse({ limit: "0" })).toThrow(ZodError);
+  });
+
+  it("rejeita valores nao numericos e fracionados", () => {
+    expect(() => paginationQuerySchema.parse({ page: "abc" })).toThrow(ZodError);
+    expect(() => paginationQuerySchema.parse({ limit: "2.5" })).toThrow(ZodError);
+  });
+});
+
+describe("parsePaginationParams", () => {
+  it("retorna null sem params (modo compat — array puro)", () => {
+    expect(parsePaginationParams(new URLSearchParams(""))).toBeNull();
+    expect(parsePaginationParams(new URLSearchParams("foo=bar"))).toBeNull();
+  });
+
+  it("ativa paginacao com apenas page (limit default 50)", () => {
+    expect(parsePaginationParams(new URLSearchParams("page=2"))).toEqual({
+      page: 2,
+      limit: 50,
+      offset: 50,
+    });
+  });
+
+  it("ativa paginacao com apenas limit (page default 1)", () => {
+    expect(parsePaginationParams(new URLSearchParams("limit=10"))).toEqual({
+      page: 1,
+      limit: 10,
+      offset: 0,
+    });
+  });
+
+  it("calcula offset = (page - 1) * limit", () => {
+    expect(parsePaginationParams(new URLSearchParams("page=4&limit=25"))).toEqual({
+      page: 4,
+      limit: 25,
+      offset: 75,
+    });
+  });
+
+  it("lanca ZodError para params invalidos (422 via handleApiError)", () => {
+    expect(() => parsePaginationParams(new URLSearchParams("page=abc"))).toThrow(ZodError);
+    expect(() => parsePaginationParams(new URLSearchParams("limit=9999"))).toThrow(ZodError);
+  });
+});

--- a/src/app/api/customers/route.ts
+++ b/src/app/api/customers/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
 import { customerSchema, customerUpdateSchema } from "@/lib/validations/customer";
-import { successResponse, errorResponse, handleApiError } from "@/lib/api-utils";
+import { parsePaginationParams } from "@/lib/validations/pagination";
+import { successResponse, errorResponse, handleApiError, paginatedResponse } from "@/lib/api-utils";
 import {
   getAllCustomers,
+  countCustomers,
   createCustomer,
   updateCustomer,
   softDeleteCustomer,
@@ -11,7 +13,7 @@ import {
 import { logActivity } from "@/services/activity";
 import { onCustomerCreated } from "@/services/automation-engine";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const session = await auth();
     if (!session?.user) return errorResponse("Não autorizado", 401);
@@ -19,8 +21,17 @@ export async function GET() {
     const tenantId = session.user.tenantId;
     if (!tenantId) return errorResponse("No tenant", 400);
 
-    const data = await getAllCustomers(tenantId);
-    return successResponse(data);
+    // Sem page/limit: array completo (compat). Com params: envelope paginado.
+    const pagination = parsePaginationParams(req.nextUrl.searchParams);
+    if (!pagination) {
+      return successResponse(await getAllCustomers(tenantId));
+    }
+
+    const [data, total] = await Promise.all([
+      getAllCustomers(tenantId, pagination),
+      countCustomers(tenantId),
+    ]);
+    return paginatedResponse(data, { page: pagination.page, limit: pagination.limit, total });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/app/api/loyalty/balances/route.ts
+++ b/src/app/api/loyalty/balances/route.ts
@@ -1,8 +1,10 @@
+import { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
-import { successResponse, errorResponse, handleApiError } from "@/lib/api-utils";
-import { getAllBalances } from "@/services/loyalty";
+import { successResponse, errorResponse, handleApiError, paginatedResponse } from "@/lib/api-utils";
+import { parsePaginationParams } from "@/lib/validations/pagination";
+import { getAllBalances, countBalances } from "@/services/loyalty";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const session = await auth();
     if (!session?.user) return errorResponse("Nao autorizado", 401);
@@ -10,8 +12,17 @@ export async function GET() {
     const tenantId = session.user.tenantId;
     if (!tenantId) return errorResponse("No tenant", 400);
 
-    const result = await getAllBalances(tenantId);
-    return successResponse(result);
+    // Sem page/limit: array completo (compat). Com params: envelope paginado.
+    const pagination = parsePaginationParams(req.nextUrl.searchParams);
+    if (!pagination) {
+      return successResponse(await getAllBalances(tenantId));
+    }
+
+    const [data, total] = await Promise.all([
+      getAllBalances(tenantId, pagination),
+      countBalances(tenantId),
+    ]);
+    return paginatedResponse(data, { page: pagination.page, limit: pagination.limit, total });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,15 +1,17 @@
 import { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
 import { successResponse, errorResponse, handleApiError } from "@/lib/api-utils";
+import { parsePaginationParams } from "@/lib/validations/pagination";
 import {
   getNotifications,
+  countNotifications,
   getUnreadCount,
   markAsRead,
   markAllAsRead,
   createNotification,
 } from "@/services/notifications";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const session = await auth();
     if (!session?.user) return errorResponse("Não autorizado", 401);
@@ -18,12 +20,27 @@ export async function GET() {
     if (!tenantId) return errorResponse("No tenant", 400);
 
     const userId = session.user.id!;
-    const [notificationList, unreadCount] = await Promise.all([
-      getNotifications(tenantId, userId),
-      getUnreadCount(tenantId, userId),
-    ]);
 
-    return successResponse({ notifications: notificationList, unreadCount });
+    // Sem page/limit: lista completa (compat). Com params: pagina + meta.
+    const pagination = parsePaginationParams(req.nextUrl.searchParams);
+    if (!pagination) {
+      const [notificationList, unreadCount] = await Promise.all([
+        getNotifications(tenantId, userId),
+        getUnreadCount(tenantId, userId),
+      ]);
+      return successResponse({ notifications: notificationList, unreadCount });
+    }
+
+    const [notificationList, unreadCount, total] = await Promise.all([
+      getNotifications(tenantId, userId, pagination),
+      getUnreadCount(tenantId, userId),
+      countNotifications(tenantId, userId),
+    ]);
+    return successResponse({
+      notifications: notificationList,
+      unreadCount,
+      pagination: { page: pagination.page, limit: pagination.limit, total },
+    });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,11 +1,18 @@
 import { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
-import { successResponse, errorResponse, handleApiError } from "@/lib/api-utils";
-import { createOrder, getAllOrders, updateOrderStatus, softDeleteOrder } from "@/services/orders";
+import { successResponse, errorResponse, handleApiError, paginatedResponse } from "@/lib/api-utils";
+import {
+  createOrder,
+  getAllOrders,
+  countOrders,
+  updateOrderStatus,
+  softDeleteOrder,
+} from "@/services/orders";
 import { logActivity } from "@/services/activity";
 import { orderCreateSchema } from "@/lib/validations/order";
+import { parsePaginationParams } from "@/lib/validations/pagination";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const session = await auth();
     if (!session?.user) return errorResponse("Não autorizado", 401);
@@ -13,8 +20,17 @@ export async function GET() {
     const tenantId = session.user.tenantId;
     if (!tenantId) return errorResponse("No tenant", 400);
 
-    const data = await getAllOrders(tenantId);
-    return successResponse(data);
+    // Sem page/limit: array completo (compat). Com params: envelope paginado.
+    const pagination = parsePaginationParams(req.nextUrl.searchParams);
+    if (!pagination) {
+      return successResponse(await getAllOrders(tenantId));
+    }
+
+    const [data, total] = await Promise.all([
+      getAllOrders(tenantId, pagination),
+      countOrders(tenantId),
+    ]);
+    return paginatedResponse(data, { page: pagination.page, limit: pagination.limit, total });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/app/api/reservations/route.ts
+++ b/src/app/api/reservations/route.ts
@@ -1,9 +1,11 @@
 import { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
 import { reservationSchema, reservationUpdateSchema } from "@/lib/validations/reservation";
-import { successResponse, errorResponse, handleApiError } from "@/lib/api-utils";
+import { parsePaginationParams } from "@/lib/validations/pagination";
+import { successResponse, errorResponse, handleApiError, paginatedResponse } from "@/lib/api-utils";
 import {
   getAllReservations,
+  countReservations,
   createReservation,
   updateReservation,
   softDeleteReservation,
@@ -11,7 +13,7 @@ import {
 import { logActivity } from "@/services/activity";
 import { onReservationConfirmed } from "@/services/automation-engine";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
     const session = await auth();
     if (!session?.user) return errorResponse("Não autorizado", 401);
@@ -19,8 +21,17 @@ export async function GET() {
     const tenantId = session.user.tenantId;
     if (!tenantId) return errorResponse("No tenant", 400);
 
-    const data = await getAllReservations(tenantId);
-    return successResponse(data);
+    // Sem page/limit: array completo (compat). Com params: envelope paginado.
+    const pagination = parsePaginationParams(req.nextUrl.searchParams);
+    if (!pagination) {
+      return successResponse(await getAllReservations(tenantId));
+    }
+
+    const [data, total] = await Promise.all([
+      getAllReservations(tenantId, pagination),
+      countReservations(tenantId),
+    ]);
+    return paginatedResponse(data, { page: pagination.page, limit: pagination.limit, total });
   } catch (error) {
     return handleApiError(error);
   }

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -5,6 +5,16 @@ export function successResponse<T>(data: T, status = 200) {
   return NextResponse.json({ success: true, data }, { status });
 }
 
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+}
+
+export function paginatedResponse<T>(data: T[], pagination: PaginationMeta, status = 200) {
+  return NextResponse.json({ success: true, data, pagination }, { status });
+}
+
 export function errorResponse(message: string, status = 400) {
   return NextResponse.json({ success: false, error: message }, { status });
 }

--- a/src/lib/validations/pagination.ts
+++ b/src/lib/validations/pagination.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+/**
+ * Paginacao padrao dos endpoints de listagem.
+ *
+ * Compatibilidade: sem `page`/`limit` na query string, as rotas mantem o
+ * comportamento antigo (array completo em `data`). Com qualquer um dos
+ * params, a rota aplica limit/offset e devolve o envelope
+ * `{ success, data, pagination: { page, limit, total } }`.
+ */
+export const paginationQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+});
+
+export type PaginationQuery = z.infer<typeof paginationQuerySchema>;
+
+export interface PageRequest {
+  page: number;
+  limit: number;
+  offset: number;
+}
+
+/**
+ * Retorna null quando nenhum param de paginacao foi enviado (modo compat).
+ * Lanca ZodError (422 via handleApiError) para valores invalidos.
+ */
+export function parsePaginationParams(searchParams: URLSearchParams): PageRequest | null {
+  if (!searchParams.has("page") && !searchParams.has("limit")) {
+    return null;
+  }
+  const parsed = paginationQuerySchema.parse({
+    page: searchParams.get("page") ?? undefined,
+    limit: searchParams.get("limit") ?? undefined,
+  });
+  return { ...parsed, offset: (parsed.page - 1) * parsed.limit };
+}

--- a/src/services/customers.ts
+++ b/src/services/customers.ts
@@ -1,14 +1,29 @@
 import { db } from "@/db";
 import { customers } from "@/db/schema";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { CustomerInput, CustomerUpdateInput } from "@/lib/validations/customer";
 
-export async function getAllCustomers(tenantId: string) {
-  return db
+export async function getAllCustomers(
+  tenantId: string,
+  pagination?: { limit: number; offset: number }
+) {
+  const query = db
     .select()
     .from(customers)
     .where(and(eq(customers.tenantId, tenantId), isNull(customers.deletedAt)))
     .orderBy(customers.createdAt);
+  if (pagination) {
+    return query.limit(pagination.limit).offset(pagination.offset);
+  }
+  return query;
+}
+
+export async function countCustomers(tenantId: string) {
+  const result = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(customers)
+    .where(and(eq(customers.tenantId, tenantId), isNull(customers.deletedAt)));
+  return Number(result[0]?.count ?? 0);
 }
 
 export async function getCustomerById(tenantId: string, id: number) {

--- a/src/services/loyalty.ts
+++ b/src/services/loyalty.ts
@@ -44,8 +44,11 @@ export async function getBalance(tenantId: string, customerId: number) {
   return result[0] ?? null;
 }
 
-export async function getAllBalances(tenantId: string) {
-  return db
+export async function getAllBalances(
+  tenantId: string,
+  pagination?: { limit: number; offset: number }
+) {
+  const query = db
     .select({
       id: loyaltyBalances.id,
       customerId: loyaltyBalances.customerId,
@@ -58,6 +61,19 @@ export async function getAllBalances(tenantId: string) {
     .innerJoin(customers, eq(loyaltyBalances.customerId, customers.id))
     .where(eq(loyaltyBalances.tenantId, tenantId))
     .orderBy(desc(loyaltyBalances.points));
+  if (pagination) {
+    return query.limit(pagination.limit).offset(pagination.offset);
+  }
+  return query;
+}
+
+export async function countBalances(tenantId: string) {
+  const result = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(loyaltyBalances)
+    .innerJoin(customers, eq(loyaltyBalances.customerId, customers.id))
+    .where(eq(loyaltyBalances.tenantId, tenantId));
+  return Number(result[0]?.count ?? 0);
 }
 
 export async function earnPoints(

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -10,8 +10,12 @@ interface CreateNotificationData {
   link?: string;
 }
 
-export async function getNotifications(tenantId: string, userId: string) {
-  return db
+export async function getNotifications(
+  tenantId: string,
+  userId: string,
+  pagination?: { limit: number; offset: number }
+) {
+  const query = db
     .select()
     .from(notifications)
     .where(
@@ -21,6 +25,23 @@ export async function getNotifications(tenantId: string, userId: string) {
       )
     )
     .orderBy(desc(notifications.createdAt));
+  if (pagination) {
+    return query.limit(pagination.limit).offset(pagination.offset);
+  }
+  return query;
+}
+
+export async function countNotifications(tenantId: string, userId: string) {
+  const result = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.tenantId, tenantId),
+        or(eq(notifications.userId, userId), isNull(notifications.userId))
+      )
+    );
+  return Number(result[0]?.count ?? 0);
 }
 
 export async function getUnreadCount(tenantId: string, userId: string) {

--- a/src/services/orders.ts
+++ b/src/services/orders.ts
@@ -1,6 +1,6 @@
 import { db } from "@/db";
 import { orders } from "@/db/schema";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 
 export async function createOrder(
   tenantId: string,
@@ -28,12 +28,27 @@ export async function createOrder(
   return result[0];
 }
 
-export async function getAllOrders(tenantId: string) {
-  return db
+export async function getAllOrders(
+  tenantId: string,
+  pagination?: { limit: number; offset: number }
+) {
+  const query = db
     .select()
     .from(orders)
     .where(and(eq(orders.tenantId, tenantId), isNull(orders.deletedAt)))
     .orderBy(orders.createdAt);
+  if (pagination) {
+    return query.limit(pagination.limit).offset(pagination.offset);
+  }
+  return query;
+}
+
+export async function countOrders(tenantId: string) {
+  const result = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(orders)
+    .where(and(eq(orders.tenantId, tenantId), isNull(orders.deletedAt)));
+  return Number(result[0]?.count ?? 0);
 }
 
 export async function updateOrderStatus(tenantId: string, id: number, status: string) {

--- a/src/services/reservations.ts
+++ b/src/services/reservations.ts
@@ -1,14 +1,29 @@
 import { db } from "@/db";
 import { reservations } from "@/db/schema";
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { ReservationInput } from "@/lib/validations/reservation";
 
-export async function getAllReservations(tenantId: string) {
-  return db
+export async function getAllReservations(
+  tenantId: string,
+  pagination?: { limit: number; offset: number }
+) {
+  const query = db
     .select()
     .from(reservations)
     .where(and(eq(reservations.tenantId, tenantId), isNull(reservations.deletedAt)))
     .orderBy(reservations.date);
+  if (pagination) {
+    return query.limit(pagination.limit).offset(pagination.offset);
+  }
+  return query;
+}
+
+export async function countReservations(tenantId: string) {
+  const result = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(reservations)
+    .where(and(eq(reservations.tenantId, tenantId), isNull(reservations.deletedAt)));
+  return Number(result[0]?.count ?? 0);
 }
 
 export async function createReservation(tenantId: string, data: ReservationInput) {


### PR DESCRIPTION
## Contexto

Finding MEDIO da auditoria: zero paginacao — `src/services/customers.ts:6-12` (`getAllCustomers`) retorna a tabela inteira do tenant; mesmo padrao nos demais services de listagem. Em producao isso escala linearmente com o volume de dados por tenant.

## Mapeamento (re-verificado)

Services sem `limit` chamados por rotas GET, priorizados por volume:

| Service | Rota GET |
|---|---|
| `getAllCustomers` (`src/services/customers.ts`) | `/api/customers` |
| `getAllOrders` (`src/services/orders.ts`) | `/api/orders` |
| `getAllReservations` (`src/services/reservations.ts`) | `/api/reservations` |
| `getAllBalances` (`src/services/loyalty.ts`) | `/api/loyalty/balances` |
| `getNotifications` (`src/services/notifications.ts`) | `/api/notifications` |

Listagens de baixo volume/config (sops, menu, documents, automations, webhooks, checklists, badges, courses) ficaram fora deste PR de proposito — mesma mecanica pode ser estendida depois com `parsePaginationParams`.

## Design (menor risco — compat total)

Consumidores atuais (`src/lib/api.ts` `fetchCustomers`/`fetchOrders`/`fetchReservations`, `src/app/(dashboard)/page.tsx:155-167`, `receitas/page.tsx:105`) esperam **array puro em `json.data`** e chamam sem query params. Por isso:

- **Sem `page`/`limit`:** resposta byte-a-byte identica a atual (array completo). Zero breaking change.
- **Com `?page=` e/ou `?limit=`:** aplica `limit`/`offset` no Drizzle e responde `{ success, data: [...], pagination: { page, limit, total } }` (novo helper `paginatedResponse` em `src/lib/api-utils.ts`). Em `/api/notifications`, que ja devolve objeto `{ notifications, unreadCount }`, o `pagination` entra dentro desse objeto.
- Validacao com Zod (`src/lib/validations/pagination.ts`): `page >= 1`, `limit` 1-100, **default limit 50**; invalido responde 422 via `handleApiError` (convencao existente do repo).
- `total` calculado por `count(*)` com os mesmos filtros da listagem (`countCustomers`, `countOrders`, `countReservations`, `countBalances`, `countNotifications`).

## Testes

- `src/__tests__/validations/pagination.test.ts` (11 testes): defaults, coercao, max 100, offset, modo compat (null sem params), ZodError.
- `src/__tests__/services/pagination.test.ts` (20 testes): mock chainable do Drizzle prova que `limit`/`offset` so sao aplicados quando pagination e passado, e que `count*` devolve numero.
- `pnpm typecheck`: verde. `pnpm lint`: 0 erros (37 warnings pre-existentes).
- `pnpm test`: **622 passed | 5 failed** — os mesmos 5 falham na `main` limpa (592 passed | 5 failed): `src/__tests__/components/*` e `auth-middleware.test.ts` (matcher desatualizado). Pre-existentes, fora do escopo.

## Follow-ups sugeridos (fora do escopo)

- Migrar o frontend para consumir o modo paginado (hoje segue no modo compat).
- Atualizar `src/app/(dashboard)/settings/api-docs/page.tsx` com os novos params.
- Estender a mecanica as listagens de menor volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)